### PR TITLE
fix(web): removing token from url bar for security purposes

### DIFF
--- a/packages/web/src/api/hasteClient.ts
+++ b/packages/web/src/api/hasteClient.ts
@@ -97,6 +97,9 @@ export class HasteClient {
         }
       } else if (idToken) {
         this.ls.set('haste:config', idToken);
+        urlSearchParams.delete('id_token');
+        const plainUrl = window.location.href.split('?')[0];
+        window.history.pushState({}, document.title, `${plainUrl}${urlSearchParams.toString()}`);
         return {
           token: idToken,
           isAuthenticated: true,


### PR DESCRIPTION
# Description

The goal of this bug fix is to improve security of the login flow. Previous, the id_token was sent and displayed as a query string parameter. While this is public knowledge, we did not believe it was a best practice to let the token remain in the URL within the browser. This fix removes the token from the URL string so the id_token is not on prominent display.

# Linked Issues

Link to any Jira issues that this pull request closes.

N/A

# Testing

N/A

# Learnings

N/A

# Outstanding Issues

N/A
